### PR TITLE
[FEAT] 게임정보 조회 기능 추가 (몽고디비연동)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }
+

--- a/src/main/java/com/wasd/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/wasd/config/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.wasd.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<String> handleGameNotFoundException(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+}

--- a/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
+++ b/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
@@ -1,0 +1,38 @@
+package com.wasd.gameInfo.controller;
+
+import com.wasd.gameInfo.dto.GameListDto;
+import com.wasd.gameInfo.entity.GameInfo;
+import com.wasd.gameInfo.service.GameInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+public class GameInfoController {
+    private final GameInfoService gameInfoService;
+
+    /**
+     * 전체 게임 목록 반환
+     * @return 게임아이디(영문) 게임명(한글) 목록 반환
+     */
+    @GetMapping("/gameInfo")
+    public ResponseEntity<List<GameListDto>> findGameInfo(){
+        return ResponseEntity.ok(gameInfoService.findGameList());
+
+    }
+
+    /**
+     * 사용자가 선택한 게임의 속성값들 반환
+     * @param gameId 게임이름
+     */
+    @GetMapping("/gameInfo/{gameId}")
+    public ResponseEntity<GameInfo> findGameInfo(@PathVariable String gameId){
+        return ResponseEntity.ok(gameInfoService.findGameInfoByGameId(gameId));
+    }
+}

--- a/src/main/java/com/wasd/gameInfo/dto/GameListDto.java
+++ b/src/main/java/com/wasd/gameInfo/dto/GameListDto.java
@@ -1,0 +1,13 @@
+package com.wasd.gameInfo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class GameListDto {
+    private String gameId;
+    private String gameNm;
+}

--- a/src/main/java/com/wasd/gameInfo/entity/GameInfo.java
+++ b/src/main/java/com/wasd/gameInfo/entity/GameInfo.java
@@ -1,0 +1,23 @@
+package com.wasd.gameInfo.entity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import java.util.Map;
+
+@Document(collection = "gameInfo")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameInfo {
+    @Id
+    private String id;
+
+    private String gameId;
+    private String gameNm;
+    private Map<String, Object> info; // 모든 데이터를 유동적으로 처리하는 Map
+}
+

--- a/src/main/java/com/wasd/gameInfo/repository/GameInfoRepository.java
+++ b/src/main/java/com/wasd/gameInfo/repository/GameInfoRepository.java
@@ -1,0 +1,16 @@
+package com.wasd.gameInfo.repository;
+
+import com.wasd.gameInfo.entity.GameInfo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GameInfoRepository extends MongoRepository<GameInfo, String > {
+
+    @Query(value = "{}", fields = "{'gameId': true, 'gameNm': true}")
+    List<GameInfo> findAllGameIdAndGameNm();
+
+    Optional<GameInfo> findByGameId(String gameID);
+}

--- a/src/main/java/com/wasd/gameInfo/service/GameInfoService.java
+++ b/src/main/java/com/wasd/gameInfo/service/GameInfoService.java
@@ -1,0 +1,27 @@
+package com.wasd.gameInfo.service;
+
+import com.wasd.gameInfo.dto.GameListDto;
+import com.wasd.gameInfo.entity.GameInfo;
+import com.wasd.gameInfo.repository.GameInfoRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class GameInfoService {
+    private final GameInfoRepository gameInfoRepository;
+
+    public List<GameListDto> findGameList(){
+        return gameInfoRepository.findAllGameIdAndGameNm().stream()
+                .map(gameInfo -> new GameListDto(gameInfo.getGameId(), gameInfo.getGameNm()))
+                .collect(Collectors.toList());
+    }
+
+    public GameInfo findGameInfoByGameId(String gameId){
+        return gameInfoRepository.findByGameId(gameId)
+                .orElseThrow(() -> new RuntimeException("게임이 없습니다"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,14 @@ spring:
         properties:
             hibernate:
                 show_sql: true
+    data:
+        mongodb:
+            host: ${mongo.host}
+            port: 27017
+            authentication-database: admin
+            username: wasd
+            password: ${mongo.password}
+            database: wasd
     thymeleaf:
         cache: false
         check-template-location: true


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 작업 사항
**빌드**
- `build.gradle` 에 몽고디비 연동사항 추가
- 현재 로컬로 진행중이므로 `secret.properties` 에는 로컬로 설정바람

**기능**
- 전체 게임 목록 반환
- 선택 게임 속성 반환

**기타**
- 모든 컨트롤러에서 Exception 발생시 처리가능한 `GlobalExceptionHandler`  생성
- 현재는 `RuntimeException` 만 잡아서 해당 body 를 `ResponseEntity` 로 간단 반환만 구현 추후 수정요망 

### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] `System.out.println`, `console.log` 등의 로그 출력 코드를 삭제했나요?

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/9e2da91b-c0ab-4bbd-9406-c4c5f10efa7d">
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/7a317cdb-3728-4502-8374-9557a9aded38">
