### PR TITLE
[FEAT] 시큐리티 활용한 OAuth2 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,25 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// basic
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// template
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.1.0'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// db
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
+	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
+	// util
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 test {

--- a/src/main/java/com/wasd/WasdApplication.java
+++ b/src/main/java/com/wasd/WasdApplication.java
@@ -2,6 +2,7 @@ package com.wasd;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class WasdApplication {

--- a/src/main/java/com/wasd/common/controller/PageController.java
+++ b/src/main/java/com/wasd/common/controller/PageController.java
@@ -6,16 +6,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class PageController {
-    @GetMapping("/")
-    public String sessionControl(HttpSession session){
-        if (session.getAttribute("user") == null){
-            return "redirect:/login";
-        }else{
-            // board 로 리다이렉트 예정
-            return "redirect:/login";
-        }
-    }
-
+    //@GetMapping("/")
+    //public String sessionControl(HttpSession session){
+    //    if (session.getAttribute("user") == null){
+    //        return "redirect:/login";
+    //    }else{
+    //        // board 로 리다이렉트 예정
+    //        return "redirect:/login";
+    //    }
+    //}
 
     /**
      *

--- a/src/main/java/com/wasd/config/CustomLogoutHandler.java
+++ b/src/main/java/com/wasd/config/CustomLogoutHandler.java
@@ -1,0 +1,40 @@
+package com.wasd.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+public class CustomLogoutHandler {
+    public LogoutHandler kakaoLogoutHandler() {
+        return (HttpServletRequest request, HttpServletResponse response, Authentication authentication) -> {
+            if (authentication != null) {
+                DefaultOAuth2User defaultOAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+                String accessToken = defaultOAuth2User.getAttributes().get("access_token").toString();
+
+                // 카카오 로그아웃 API 호출
+                RestTemplate restTemplate = new RestTemplate();
+                String logoutUrl = "https://kapi.kakao.com/v1/user/logout";
+
+                HttpHeaders headers = new HttpHeaders();
+                headers.setBearerAuth(accessToken);
+                headers.setContentType(MediaType.APPLICATION_JSON);
+
+                try {
+                    restTemplate.postForEntity(logoutUrl, null, String.class);
+                    log.info("카카오 로그아웃 성공");
+                } catch (Exception e) {
+                    log.error("카카오 로그아웃 실패: {}", e.getMessage());
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/wasd/config/security/CustomOAuth2User.java
+++ b/src/main/java/com/wasd/config/security/CustomOAuth2User.java
@@ -1,0 +1,32 @@
+package com.wasd.config.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2UserInfo userInfo;
+    private final boolean isSigned;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return userInfo.getId();
+    }
+}

--- a/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
+++ b/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
@@ -1,0 +1,75 @@
+package com.wasd.config.security;
+
+import com.wasd.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Builder
+@Getter
+@ToString
+public class OAuth2UserInfo {
+    private String id;
+    private String email;
+    private String provider;
+    private String nickname;
+    private String profileImg;
+
+    public static OAuth2UserInfo of(String provider, Map<String, Object> attributes) {
+        switch (provider) {
+            case "google":
+                return ofGoogle(attributes);
+            case "kakao":
+                return ofKakao(attributes);
+            case "naver":
+                return ofNaver(attributes);
+            default:
+                throw new RuntimeException("제공되지 않는 로그인 유형입니다.");
+        }
+    }
+
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        return OAuth2UserInfo.builder()
+                .provider("google")
+                .id("google_" + (String) attributes.get("sub"))
+                .nickname((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .profileImg((String) attributes.get("picture"))
+                .build();
+    }
+
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        return OAuth2UserInfo.builder()
+                .provider("kakao")
+                .id("kakao_" + attributes.get("id").toString())
+                .nickname((String) ((Map) attributes.get("properties")).get("nickname"))
+                .email((String) ((Map) attributes.get("kakao_account")).get("email"))
+                .profileImg((String) ((Map) attributes.get("properties")).get("profile_image"))
+                // .profileImg((String) ((Map) attributes.get("properties")).get("thumbnail_image"))
+                .build();
+    }
+
+    private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
+        Map<String, String> res = (Map) attributes.get("response");
+        return OAuth2UserInfo.builder()
+                .provider("naver")
+                .id("naver_" + res.get("id"))
+                .nickname(res.get("name"))
+                .email(res.get("email"))
+                .profileImg(res.get("profile_image"))
+                .build();
+    }
+
+    public User toEntity(){
+        return User.builder()
+                .userId(id)
+                .nickname(nickname)
+                .provider(provider)
+                .profileImg(profileImg)
+                .email(email)
+                .build();
+    }
+}
+

--- a/src/main/java/com/wasd/config/security/OAuth2UserService.java
+++ b/src/main/java/com/wasd/config/security/OAuth2UserService.java
@@ -1,0 +1,45 @@
+package com.wasd.config.security;
+
+import com.wasd.user.repository.UserRepository;
+import com.wasd.user.entity.User;
+import lombok.AllArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class OAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+    // 로그인 시 호출
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // provider 추가 (kakao || naver || google)
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        // 인증 객체를 가지고 제공자로 구분해서 필요한 정보 담은 객체
+        OAuth2UserInfo userInfo = OAuth2UserInfo.of(provider, oAuth2User.getAttributes());
+
+        // 해당 아이디로 가입되어 있는지 여부
+        User byId = userRepository.findById(userInfo.getId()).orElse(null);
+        boolean isSigned = byId != null;
+
+        /*
+        // accssToken
+        OAuth2AccessToken accessToken = userRequest.getAccessToken();
+        // Role generate
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_ADMIN");
+        // nameAttributeKey
+        String userNameAttr = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+                */
+
+        return new CustomOAuth2User(userInfo, isSigned);
+    }
+}

--- a/src/main/java/com/wasd/config/security/SecurityConfig.java
+++ b/src/main/java/com/wasd/config/security/SecurityConfig.java
@@ -1,0 +1,60 @@
+package com.wasd.config.security;
+
+import com.wasd.config.CustomLogoutHandler;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+@Configuration
+@EnableWebSecurity
+@AllArgsConstructor
+@Slf4j
+public class SecurityConfig {
+    private final OAuth2UserService oAuth2UserService;
+    private final CustomLogoutHandler logoutHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화 (필요에 따라 설정)
+                // .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()) // 모든 경로 인증 없이 허용
+                .authorizeHttpRequests(auth -> auth
+                        // 로그인페이지 말고는 인증 안되게
+                        .requestMatchers("/login").permitAll()
+                        // css 와 image 도 url 등록해줘야지 안깨짐
+                        .requestMatchers("/css/**", "/images/**", "/js/**").permitAll()
+                        // 다른 모든 페이지는 인증 후에 접속가능
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2Configurer -> oauth2Configurer
+                        .loginPage("/login")
+                        .successHandler(successHandler())
+                        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))// 사용자 정보를 처리하는 서비스 설정
+                )
+                // TODO 로그아웃 기능 구현해야댐
+                .logout(logout -> logout
+                        .logoutUrl("/logout") // 로그아웃 URL 설정 (기본값: /logout)
+                        .logoutSuccessUrl("/login") // 로그아웃 성공 시 리다이렉트할 URL
+                        .invalidateHttpSession(true) // 세션 무효화
+                        .addLogoutHandler(logoutHandler.kakaoLogoutHandler())
+                        .deleteCookies("JSESSIONID") // 특정 쿠키 삭제 (예: JSESSIONID)
+                );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler successHandler() {
+        // 로그인 인증 후 들어옴
+        return (request, response, authentication) -> {
+            CustomOAuth2User userInfo = (CustomOAuth2User) authentication.getPrincipal();
+            log.info("OAuth2 Success ::" + userInfo.getUserInfo().toString());
+            // 가입여부에 따라 redirect
+            response.sendRedirect(userInfo.isSigned() ? "/board" : "/join");
+        };
+    }
+}

--- a/src/main/java/com/wasd/user/controller/UserController.java
+++ b/src/main/java/com/wasd/user/controller/UserController.java
@@ -1,9 +1,16 @@
 package com.wasd.user.controller;
 
+import com.wasd.config.security.CustomOAuth2User;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class UserController {
-
-
+    // 시큐리티 저장된 세션 사용하는 법
+    @GetMapping("/test")
+    public CustomOAuth2User test(@AuthenticationPrincipal CustomOAuth2User oAuth2User, HttpServletRequest request) {
+        return oAuth2User;
+    }
 }

--- a/src/main/java/com/wasd/user/entity/User.java
+++ b/src/main/java/com/wasd/user/entity/User.java
@@ -1,0 +1,45 @@
+package com.wasd.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="user_info")
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    private String userId;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String nickname;
+
+    @Column(nullable = false, length = 10)
+    private String provider;
+
+    @Lob
+    @Column(nullable = true)
+    private String profileImg;
+
+    @Column(nullable = false)
+    private int yearOfBirth;
+
+    @Column(nullable = true, length = 4)
+    private String mbti;
+
+    @Column(nullable = true)
+    private LocalDateTime startTime;
+
+    @Column(nullable = true)
+    private LocalDateTime endTime;
+}
+

--- a/src/main/java/com/wasd/user/repository/UserRepository.java
+++ b/src/main/java/com/wasd/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.wasd.user.repository;
+
+import com.wasd.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,45 @@ spring:
         enabled: true
         prefix: classpath:/templates
         suffix: .html
+    security:
+        oauth2:
+            client:
+                registration:
+                    kakao:
+                        client-id: ${kakao.client-id}
+                        client-secret: ${kakao.client-secret}
+                        client-authentication-method: client_secret_post
+                        redirect-uri: http://localhost:8088/login/oauth2/code/kakao
+                        authorization-grant-type: authorization_code
+                        client-name: kakao
+                        scope:
+                            - profile_nickname
+                            - profile_image
+                            - account_email
+                    naver:
+                        client-id: ${naver.client-id}
+                        client-secret: ${naver.client-secret}
+                        client-authentication-method: client_secret_post
+                        redirect-uri: http://localhost:8088/login/oauth2/code/naver
+                        authorization-grant-type: authorization_code
+                        client-name: naver
+                        scope:
+                            - profile
+                            - email
+                    google:
+                        client-id: ${google.client-id}
+                        client-secret: ${google.client-secret}
+                        scope:
+                            - profile
+                            - email
+                provider:
+                    kakao:
+                        authorization-uri: https://kauth.kakao.com/oauth/authorize
+                        token-uri: https://kauth.kakao.com/oauth/token
+                        user-info-uri: https://kapi.kakao.com/v2/user/me
+                        user-name-attribute: id
+                    naver:
+                        authorization-uri: https://nid.naver.com/oauth2.0/authorize
+                        token-uri: https://nid.naver.com/oauth2.0/token
+                        user-info-uri: https://openapi.naver.com/v1/nid/me
+                        user-name-attribute: response

--- a/src/main/resources/templates/pages/user/login.html
+++ b/src/main/resources/templates/pages/user/login.html
@@ -23,13 +23,13 @@
     </div>
 
     <div class="login-sns-btn-box">
-        <button class="login-sns-btns" onClick="window.location.href='/join'">
+        <button class="login-sns-btns" onClick="window.location.href='/oauth2/authorization/kakao'">
             <img th:src="@{/images/kakao.png}" alt="kakaoLogin" style="width: 100%;">
         </button>
-        <button class="login-sns-btns">
+        <button class="login-sns-btns" onClick="window.location.href='/oauth2/authorization/naver'">
             <img th:src="@{/images/naver.png}" alt="naverLogin" style="width: 100%;">
         </button>
-        <button class="login-sns-btns">
+        <button class="login-sns-btns" onClick="window.location.href='/oauth2/authorization/google'">
             <img th:src="@{/images/google.png}" alt="googleLogin" style="width: 100%;">
         </button>
     </div>

--- a/src/test/java/com/wasd/gameInfo/unit/GameInfoServiceTest.java
+++ b/src/test/java/com/wasd/gameInfo/unit/GameInfoServiceTest.java
@@ -1,0 +1,78 @@
+package com.wasd.gameInfo.unit;
+
+import com.wasd.gameInfo.dto.UserGameInfoDto;
+import com.wasd.gameInfo.entity.GameInfo;
+import com.wasd.gameInfo.entity.UserGameInfo;
+import com.wasd.gameInfo.repository.UserGameInfoRepository;
+import com.wasd.gameInfo.service.GameInfoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GameInfoServiceTest {
+
+    @Mock
+    UserGameInfoRepository userGameInfoRepository;
+
+    @Mock
+    HttpSession session;
+
+    @InjectMocks
+    GameInfoService gameInfoService;
+
+    private UserGameInfo userGameInfo;
+
+    @BeforeEach
+    public void setUp() {
+        // Mockito 초기화
+        MockitoAnnotations.openMocks(this);
+
+        // Dummy UserGameInfo 설정
+        userGameInfo = UserGameInfo.builder()
+                .id("1")
+                .userId("test")
+                .gameInfoList(Arrays.asList(
+                        GameInfo.builder()
+                                .gameId("lol")
+                                .gameNm("롤(리그오브레전드)")
+                                .info(Map.of("tier", "silver", "lane", "mid", "playStyle", "defensive"))
+                                .build(),
+                        GameInfo.builder()
+                                .gameId("lostark")
+                                .gameNm("로스트아크")
+                                .info(Map.of("server", "mari", "class", "warrior", "playStyle", "balanced"))
+                                .build()
+                ))
+                .build();
+    }
+
+    @Test
+    @DisplayName("게임 정보 삭제 테스트")
+    public void deleteUserGameInfoTest() {
+        // given
+        String userId = "test";
+        String gameId = "lol";
+
+        when(session.getAttribute("userId")).thenReturn(userId);
+        when(userGameInfoRepository.findByUserId(userId)).thenReturn(Optional.of(userGameInfo));
+
+        // when
+        UserGameInfoDto result = gameInfoService.deleteUserGameInfo(gameId, session);
+
+        assertEquals(1, result.getGameInfoList().size());
+        assertEquals("lostark", result.getGameInfoList().get(0).getGameId());
+    }
+
+}
+


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 작업 사항

- 유저 테이블 엔티티와 JPA 레포지토리 생성함 (아이디는 소셜에서 제공하는 아이디와 provider 합쳐서 String 형식으로 만듦)
- 인증 후 시큐리티 세션을 보유하고 `join` 으로 리다이렉트됨
  - 만약 가입한 유저라면 `board` 로 리다이렉트
- 시큐리티와 Oauth 활용해서 소셜로그인 기능 구현(카카오, 네이버, 구글)
- 인증 후 `@AuthenticationPrincipal CustomOAuth2User` 을 통해 인증객체 사용가능
  - `CustomOAuth2User` 객체 내에는 유저정보 담고있는 `OAuth2UserInfo` 가 있으므로 get 으로 사용가능
  - `OAuth2UserInfo` 는 외부에서 제공하는 정보중 필요한 정보가 모두 담겨있음. `toEntity` 로 유저엔티티로 변환가능
- `login` 페이지 외 모든 페이지는 인증 후 접근 가능하도록 막음


*인증키는 노션에 업데이트*

### 추가 작업사항
- [ ] 로그아웃 기능 구현

### 요청사항

- 인증 후 가입까지 확인 되야 다른 페이지들 접근 가능하도록 기능 추가 바람 
- 인증객체 활용해서 DB 에 회원정보 insert 기능 추가 바람
- redirect 페이지 작성 요청 `board` `join`

### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?


### 스크린샷 (필요시)
<img width="1805" alt="image" src="https://github.com/user-attachments/assets/c9cac17d-0cea-453c-b015-46f9e0e54e9f">

### 추가 정보
추가적인 정보나 설명이 필요할 경우 작성해주세요.
