### PR TITLE
[FEAT] API 요청시사용하기 위한 OAuth 권한 요청 API 생성

### DIFF
--- a/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
+++ b/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
@@ -1,6 +1,7 @@
 package com.wasd.config.security;
 
 import com.wasd.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -10,6 +11,7 @@ import java.util.Map;
 @Builder
 @Getter
 @ToString
+@AllArgsConstructor
 public class OAuth2UserInfo {
     private String id;
     private String email;
@@ -18,16 +20,12 @@ public class OAuth2UserInfo {
     private String profileImg;
 
     public static OAuth2UserInfo of(String provider, Map<String, Object> attributes) {
-        switch (provider) {
-            case "google":
-                return ofGoogle(attributes);
-            case "kakao":
-                return ofKakao(attributes);
-            case "naver":
-                return ofNaver(attributes);
-            default:
-                throw new RuntimeException("제공되지 않는 로그인 유형입니다.");
-        }
+        return switch (provider) {
+            case "google" -> ofGoogle(attributes);
+            case "kakao" -> ofKakao(attributes);
+            case "naver" -> ofNaver(attributes);
+            default -> throw new RuntimeException("제공되지 않는 로그인 유형입니다.");
+        };
     }
 
     private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {

--- a/src/main/java/com/wasd/config/security/OAuthTempController.java
+++ b/src/main/java/com/wasd/config/security/OAuthTempController.java
@@ -1,0 +1,60 @@
+package com.wasd.config.security;
+
+import com.wasd.user.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@Slf4j
+@RequiredArgsConstructor
+public class OAuthTempController {
+    @Value("${kakao.client-id}")
+    private String SECRET_KEY;
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/auth/temp")
+    public ResponseEntity<String> forceAuthentication(@RequestParam String userId, @RequestParam String secretKey, HttpSession session) {
+        if (!secretKey.equals(SECRET_KEY)) throw new RuntimeException("인증키가 다릅니다.");
+
+        // 사용자 정보가 있으면 DB에서, 없으면 하드코딩된 값 사용
+        OAuth2UserInfo userInfo = userRepository.findById(userId)
+                .map(user -> new OAuth2UserInfo(user.getUserId(), user.getEmail(), user.getProvider(), user.getNickname(), user.getProfileImg()))
+                .orElseGet(() -> new OAuth2UserInfo(userId, "wasd@wasd.com", "kakao", "wasd", "http://localhost:8088/images/wasd_logo.png"));
+
+        // DB 정보에 따라 권한 부여
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_GUEST");
+        if (userRepository.existsById(userId)) authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        // 임의로 인증할 인증 객체를 설정합니다.
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userInfo, authorities);
+        Authentication authentication = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), userId);
+
+        // SecurityContext에 인증 정보를 설정합니다.
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+
+        // SecurityContext를 세션에 저장합니다.
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+        log.info("TEMP API USER JOIN::" + userInfo);
+
+        // 응답 반환
+        return ResponseEntity.ok(userInfo.toString());
+    }
+}

--- a/src/main/java/com/wasd/config/security/SecurityConfig.java
+++ b/src/main/java/com/wasd/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -27,8 +28,8 @@ public class SecurityConfig {
 
                         // 로그인페이지 말고는 인증 안되게 ( + 정적파일 접근권한도 추가해줘야함)
                         .requestMatchers("/login", "/css/**", "/images/**", "/js/**", "/error").permitAll()
+                        .requestMatchers("/auth/temp").permitAll()
 
-                        .requestMatchers("/gameInfo/**").permitAll()
                         /*// 특정 HTTP 메서드에 대한 제한 설정
                         .requestMatchers(HttpMethod.GET, "/public/**").permitAll() // GET 요청은 인증 없이 허용
                         .requestMatchers(HttpMethod.POST, "/private/**").authenticated() // POST 요청은 인증 필요
@@ -59,8 +60,8 @@ public class SecurityConfig {
             CustomOAuth2User userInfo = (CustomOAuth2User) authentication.getPrincipal();
             Collection<? extends GrantedAuthority> authorities = userInfo.getAuthorities();
 
-            log.info("OAuth2 Success::" + userInfo.getUserInfo().toString() +
-                    ", Roles::" + authorities.stream()
+            log.info("OAuth2 Success::" + userInfo
+                    +", Roles::" + authorities.stream()
                     .map(GrantedAuthority::getAuthority)
                     .collect(Collectors.joining(", ")));
 
@@ -70,5 +71,12 @@ public class SecurityConfig {
 
             response.sendRedirect(isSigned ? "/board" : "/join");
         };
+    }
+
+    // Security에서 사용자의 인증 정보를 HttpSession에 저장하고 관리하여 여러 요청 간에 인증 상태를 유지하게 함
+    // This is for OAuthTempController
+    @Bean
+    public HttpSessionSecurityContextRepository securityContextRepository() {
+        return new HttpSessionSecurityContextRepository();
     }
 }

--- a/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
+++ b/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
@@ -24,7 +24,6 @@ public class GameInfoController {
     @GetMapping
     public ResponseEntity<List<GameInfoDto>> findGameInfo(){
         return ResponseEntity.ok(gameInfoService.findGameInfo());
-
     }
 
     /**
@@ -68,8 +67,6 @@ public class GameInfoController {
         // 이 메소드는 가입시에만 호출되므로 drop 후 insert 로 구현함
         return ResponseEntity.ok(gameInfoService.insertUserGameInfo(gameInfoDtoList, oAuth2User.getUserInfo().getId()));
     }
-
-    // 유저가 선택한 게임 정보 update
 
     /**
      * 유저 선택 게임 정보 업데이트


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 작업 사항

- API 요청시 OAuth 권한 세션 획득 불가문제 해결
- 포스트맨에서 하단 preRequest 날리면 세션 부여 후 해당 세션으로 작업가능
- 요청시 `userId` 가 실제 DB 에 있으면 해당값과 `ROLE_USER` 를 가져오고, 그렇지 않다면 더미값 반환

### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?


### 스크린샷 (필요시)
![image](https://github.com/user-attachments/assets/7ffb3bc4-a20c-4983-aaba-4d0baf53b993)



### 추가 정보
추가적인 정보나 설명이 필요할 경우 작성해주세요.
