### PR TITLE
[FEAT] 세션 DB 저장 및 로그인 페이지 redirect 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.session:spring-session-jdbc'
 }
 
 test {

--- a/src/main/java/com/wasd/WasdApplication.java
+++ b/src/main/java/com/wasd/WasdApplication.java
@@ -2,7 +2,6 @@ package com.wasd;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class WasdApplication {

--- a/src/main/java/com/wasd/common/controller/PageController.java
+++ b/src/main/java/com/wasd/common/controller/PageController.java
@@ -13,7 +13,11 @@ import java.util.Collection;
 @Controller
 public class PageController {
     @GetMapping("/login")
-    public String loginPage(){
+    public String loginPage(@AuthenticationPrincipal CustomOAuth2User oAuth2User){
+        if (oAuth2User != null) {
+            return "redirect:/join";
+        }
+        // 인증되지 않은 경우 로그인 페이지를 보여줌
         return "/pages/user/login";
     }
 

--- a/src/main/java/com/wasd/config/security/CustomOAuth2User.java
+++ b/src/main/java/com/wasd/config/security/CustomOAuth2User.java
@@ -3,16 +3,16 @@ package com.wasd.config.security;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, Serializable {
     private final OAuth2UserInfo userInfo;
     private final List<GrantedAuthority> authorities;
 

--- a/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
+++ b/src/main/java/com/wasd/config/security/OAuth2UserInfo.java
@@ -6,13 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @Builder
 @Getter
 @ToString
 @AllArgsConstructor
-public class OAuth2UserInfo {
+public class OAuth2UserInfo implements Serializable {
     private String id;
     private String email;
     private String provider;
@@ -31,35 +32,36 @@ public class OAuth2UserInfo {
     private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
         return OAuth2UserInfo.builder()
                 .provider("google")
-                .id("google_" + (String) attributes.get("sub"))
-                .nickname((String) attributes.get("name"))
-                .email((String) attributes.get("email"))
-                .profileImg((String) attributes.get("picture"))
+                .id("google_" + String.valueOf(attributes.get("sub"))) // 안전한 처리
+                .nickname(String.valueOf(attributes.get("name"))) // 안전한 처리
+                .email(String.valueOf(attributes.get("email"))) // 안전한 처리
+                .profileImg(String.valueOf(attributes.get("picture"))) // 안전한 처리
                 .build();
     }
 
     private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
         return OAuth2UserInfo.builder()
                 .provider("kakao")
-                .id("kakao_" + attributes.get("id").toString())
-                .nickname((String) ((Map) attributes.get("properties")).get("nickname"))
-                .email((String) ((Map) attributes.get("kakao_account")).get("email"))
-                .profileImg((String) ((Map) attributes.get("properties")).get("profile_image"))
-                // .profileImg((String) ((Map) attributes.get("properties")).get("thumbnail_image"))
+                .id("kakao_" + String.valueOf(attributes.get("id"))) // 안전한 처리
+                .nickname(String.valueOf(properties.get("nickname"))) // 안전한 처리
+                .email(String.valueOf(kakaoAccount.get("email"))) // 안전한 처리
+                .profileImg(String.valueOf(properties.get("profile_image"))) // 안전한 처리
                 .build();
     }
 
     private static OAuth2UserInfo ofNaver(Map<String, Object> attributes) {
-        Map<String, String> res = (Map) attributes.get("response");
+        Map<String, Object> res = (Map<String, Object>) attributes.get("response");
         return OAuth2UserInfo.builder()
                 .provider("naver")
-                .id("naver_" + res.get("id"))
-                .nickname(res.get("name"))
-                .email(res.get("email"))
-                .profileImg(res.get("profile_image"))
+                .id("naver_" + String.valueOf(res.get("id"))) // 안전한 처리
+                .nickname(String.valueOf(res.get("name"))) // 안전한 처리
+                .email(String.valueOf(res.get("email"))) // 안전한 처리
+                .profileImg(String.valueOf(res.get("profile_image"))) // 안전한 처리
                 .build();
     }
-
     public User toEntity(){
         return User.builder()
                 .userId(id)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
         url: ${psql.url}
         username: ${psql.username}
         password: ${psql.password}
+    session:
+        jdbc:
+          initialize-schema: always
+        timeout: 24h
     jpa:
         hibernate:
             ddl-auto: update

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,5 +6,8 @@
 </head>
 <body>
    <h1>welcome</h1>
+<script>
+    window.location.href="/login"
+</script>
 </body>
 </html>


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 기타

### 작업 사항

close #17 #16 

- 세션 저장소 인메모리에서 DB 로 변경
  - 24시간유지 (스프링 자동생성 테이블)
  - 브라우저 종료 전까지 계속 유지 (서버 재시작시에도)

- 시큐리티에서 인증 전에는 무조건 login 만 가능하도록 해둔 상태
  - index.html -> login 으로 redirect
  - login 페이지에서 세션이 있다면 -> join
  - join 에서 유저 ROLE 체크후 join || main 으로 redirect

### 추가 정보
/logout 접속시 세션삭제, DB 에서도 세션 지워짐
#18 해결 필요
---

### 스크린샷 (필요시)

### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?

