### PR TITLE
[FEAT] 그룹게임정보 RestAPI 구현 & 그룹 정보 생성

### DIFF
--- a/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
+++ b/src/main/java/com/wasd/gameInfo/controller/GameInfoController.java
@@ -2,6 +2,7 @@ package com.wasd.gameInfo.controller;
 
 import com.wasd.config.security.CustomOAuth2User;
 import com.wasd.gameInfo.dto.GameInfoDto;
+import com.wasd.gameInfo.dto.GroupGameInfoDto;
 import com.wasd.gameInfo.dto.UserGameInfoDto;
 import com.wasd.gameInfo.service.GameInfoService;
 import lombok.RequiredArgsConstructor;
@@ -88,5 +89,26 @@ public class GameInfoController {
     @DeleteMapping("/user/game")
     public ResponseEntity<UserGameInfoDto> deleteUserGameInfo(@RequestParam String gameId, @AuthenticationPrincipal CustomOAuth2User oAuth2User){
         return ResponseEntity.ok(gameInfoService.deleteUserGameInfo(gameId, oAuth2User.getUserInfo().getId()));
+    }
+
+
+    /**
+     * 그룹 아이디로 선택한 그룹의 게임 정보 조회
+     * @param groupId 그룹아이디
+     * @return GroupGameInfoDto 선택한 그룹의 게임 정보
+     */
+    @GetMapping("/group/{groupId}")
+    public ResponseEntity<GroupGameInfoDto> findGroupGameInfo(@PathVariable Long groupId){
+        return ResponseEntity.ok(gameInfoService.findGroupGameInfo(groupId));
+    }
+
+    /**
+     * 선택한 게임에 해당하는 그룹_게임 목록 조회
+     * @param gameId 게임 아이디
+     * @return List<GroupGameInfoDto> 선택한 게임에 해당하는 그룹 목록
+     */
+    @GetMapping("/group/game/{gameId}")
+    public ResponseEntity<List<GroupGameInfoDto>> findGroupGameListByGameId(@PathVariable String gameId){
+        return ResponseEntity.ok(gameInfoService.findGroupGameListByGameId(gameId));
     }
 }

--- a/src/main/java/com/wasd/gameInfo/dto/GroupGameInfoDto.java
+++ b/src/main/java/com/wasd/gameInfo/dto/GroupGameInfoDto.java
@@ -1,0 +1,24 @@
+package com.wasd.gameInfo.dto;
+
+import com.wasd.gameInfo.entity.GroupGameInfo;
+import com.wasd.gameInfo.entity.UserGameInfo;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupGameInfoDto {
+
+    private Long groupId;
+    private GameInfoDto gameInfo;
+
+    public GroupGameInfo toEntity() {
+        return GroupGameInfo.builder()
+                .groupId(this.groupId)
+                .gameInfo(this.gameInfo.toEntity())
+                .build();
+    }
+}

--- a/src/main/java/com/wasd/gameInfo/entity/GroupGameInfo.java
+++ b/src/main/java/com/wasd/gameInfo/entity/GroupGameInfo.java
@@ -1,0 +1,32 @@
+package com.wasd.gameInfo.entity;
+
+import com.wasd.gameInfo.dto.GroupGameInfoDto;
+import com.wasd.gameInfo.dto.UserGameInfoDto;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "groupGameInfo")
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupGameInfo {
+    @Id
+    private String id;
+
+    private Long groupId;
+
+    private GameInfo gameInfo;
+
+    public GroupGameInfoDto toDto(){
+        return GroupGameInfoDto.builder()
+                .groupId(this.groupId)
+                .gameInfo(this.gameInfo.toDto())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wasd/gameInfo/repository/GroupGameInfoRepository.java
+++ b/src/main/java/com/wasd/gameInfo/repository/GroupGameInfoRepository.java
@@ -1,0 +1,31 @@
+package com.wasd.gameInfo.repository;
+
+import com.wasd.gameInfo.entity.GroupGameInfo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupGameInfoRepository extends MongoRepository<GroupGameInfo, String> {
+
+    /**
+     * groupId로 GroupGameInfo 조회
+     * @param groupId
+     * @return
+     */
+    Optional<GroupGameInfo>  findByGroupId(Long groupId);
+
+    /**
+     * gameId로 GroupGameInfo 목록 조회
+     * @param gameId
+     * @return
+     */
+    List<GroupGameInfo> findByGameInfo_GameId(String gameId);
+
+
+    /**
+     * groupId로 GroupGameInfo 삭제
+     * @param groupId
+     */
+    void deleteByGroupId(Long groupId);
+}

--- a/src/main/java/com/wasd/gameInfo/service/GameInfoService.java
+++ b/src/main/java/com/wasd/gameInfo/service/GameInfoService.java
@@ -1,12 +1,16 @@
 package com.wasd.gameInfo.service;
 
 import com.wasd.gameInfo.dto.GameInfoDto;
+import com.wasd.gameInfo.dto.GroupGameInfoDto;
 import com.wasd.gameInfo.dto.UserGameInfoDto;
 import com.wasd.gameInfo.entity.GameInfo;
+import com.wasd.gameInfo.entity.GroupGameInfo;
 import com.wasd.gameInfo.entity.UserGameInfo;
 import com.wasd.gameInfo.repository.GameInfoRepository;
+import com.wasd.gameInfo.repository.GroupGameInfoRepository;
 import com.wasd.gameInfo.repository.UserGameInfoRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -18,6 +22,7 @@ import java.util.stream.Collectors;
 public class GameInfoService {
     private final GameInfoRepository gameInfoRepository;
     private final UserGameInfoRepository userGameInfoRepository;
+    private final GroupGameInfoRepository groupGameInfoRepository;
 
     public List<GameInfoDto> findGameInfo() {
         return gameInfoRepository.findAllGameIdAndGameNm()
@@ -126,5 +131,78 @@ public class GameInfoService {
         UserGameInfo save = userGameInfoRepository.save(deleted);
         return save.toDto();
     }
+
+
+    /**
+     * 그룹 아이디로 그룹_게임 정보 조회
+     * @param groupId 그룹 아이디
+     * @return GroupGameInfoDto
+     */
+    public GroupGameInfoDto findGroupGameInfo(Long groupId) {
+        return groupGameInfoRepository.findByGroupId(groupId)
+                .map(GroupGameInfo::toDto)
+                .orElseThrow(() -> new RuntimeException("그룹 아이디에 해당하는 정보가 없습니다."));
+    }
+
+    /**
+     * 게임 아이디로 그룹_게임 목록 조회
+     * @param gameId 게임 아이디
+     * @return List<GroupGameInfoDto>
+     */
+    public List<GroupGameInfoDto> findGroupGameListByGameId(String gameId){
+        return groupGameInfoRepository.findByGameInfo_GameId(gameId).stream()
+                .map(GroupGameInfo::toDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 그룹게임정보 생성
+     * @param gameInfoDto 그룹이 선택한 게임 정보
+     * @param groupId 그룹 아이디
+     * @return 생성된 그룹게임정보
+     */
+    public GroupGameInfoDto insertGroupGameInfo(GameInfoDto gameInfoDto, Long groupId) {
+        // 혹시 만약 있다면 삭제 먼저
+        groupGameInfoRepository.findByGroupId(groupId).ifPresent(groupGameInfoRepository::delete);
+        GroupGameInfo save = GroupGameInfo.builder()
+                .groupId(groupId)
+                .gameInfo(gameInfoDto.toEntity())
+                .build();
+        return groupGameInfoRepository.save(save).toDto();
+    }
+
+    /**
+     * 그룹게임정보 수정
+     * @param gameInfoDto 그룹이 선택한 수정된 게임 정보
+     * @param groupId 그룹 아이디
+     * @return 수정된 그룹게임정보
+     */
+    public GroupGameInfoDto updateGroupGameInfo(GameInfoDto gameInfoDto, Long groupId) {
+
+        // 기존 그룹 게임 정보 조회
+        GroupGameInfo byGroupId = groupGameInfoRepository.findByGroupId(groupId)
+                .orElseThrow(() -> new RuntimeException("그룹 아이디에 해당하는 정보가 없습니다"));
+
+        // 기존 정보 업데이트
+        GroupGameInfo save = GroupGameInfo.builder()
+                .groupId(groupId)
+                .gameInfo(gameInfoDto.toEntity())
+                .build();
+        return groupGameInfoRepository.save(save).toDto();
+    }
+
+    /**
+     * 그룹게임정보 삭제
+     * @param groupId 그룹 아이디
+     * @return 삭제된 그룹게임정보
+     */
+    public GroupGameInfoDto deleteGroupGameInfo(Long groupId) {
+        // 기존 그룹 게임 정보 조회
+        GroupGameInfo delete = groupGameInfoRepository.findByGroupId(groupId)
+                .orElseThrow(() -> new RuntimeException("그룹 아이디에 해당하는 정보가 없습니다"));
+        groupGameInfoRepository.deleteByGroupId(groupId);
+        return delete.toDto();
+    }
+
 
 }

--- a/src/main/java/com/wasd/group/controller/GroupController.java
+++ b/src/main/java/com/wasd/group/controller/GroupController.java
@@ -1,0 +1,28 @@
+package com.wasd.group.controller;
+
+import com.wasd.gameInfo.dto.GameInfoDto;
+import com.wasd.group.dto.GroupDto;
+import com.wasd.group.service.GroupService;
+import com.wasd.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/group")
+@RequiredArgsConstructor
+public class GroupController {
+
+    private final GroupService groupService;
+
+
+
+
+
+
+}

--- a/src/main/java/com/wasd/group/dto/GroupDto.java
+++ b/src/main/java/com/wasd/group/dto/GroupDto.java
@@ -1,0 +1,37 @@
+package com.wasd.group.dto;
+
+import com.wasd.gameInfo.dto.GameInfoDto;
+import com.wasd.group.entity.Group;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupDto {
+
+    private Long groupId;
+    private String groupNm;
+    private String groupDc;
+    private String groupImg;
+    private Integer maxUserCount;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    private GameInfoDto gameInfo;
+
+    public Group toEntity(){
+        return Group.builder()
+                .groupId(this.groupId)
+                .groupNm(this.groupNm)
+                .groupDc(this.groupDc)
+                .groupImg(this.groupImg)
+                .maxUserCount(this.maxUserCount)
+                .startTime(this.startTime)
+                .endTime(this.endTime)
+                .build();
+    }
+}

--- a/src/main/java/com/wasd/group/dto/GroupUserDto.java
+++ b/src/main/java/com/wasd/group/dto/GroupUserDto.java
@@ -1,0 +1,35 @@
+package com.wasd.group.dto;
+
+import com.wasd.gameInfo.dto.GameInfoDto;
+import com.wasd.group.entity.Group;
+import com.wasd.group.entity.GroupUser;
+import com.wasd.user.dto.UserDto;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupUserDto {
+
+    private Long groupUserId;
+    private GroupDto group;
+    private UserDto user;
+    private Integer role;
+
+    /**
+     * dto -> entity
+     * @return
+     */
+    public GroupUser toEntity(){
+        return GroupUser.builder()
+                .groupUserId(this.groupUserId)
+                .group(this.group.toEntity())
+                .user(this.user.toEntity())
+                .role(this.role)
+                .build();
+    }
+}

--- a/src/main/java/com/wasd/group/entity/Group.java
+++ b/src/main/java/com/wasd/group/entity/Group.java
@@ -1,0 +1,56 @@
+package com.wasd.group.entity;
+
+import com.wasd.group.dto.GroupDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name="group_info")
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
+    private Long groupId;
+
+    @Column(name = "group_nm", nullable = false, length = 255)
+    private String groupNm;
+
+    @Column(name = "group_dc", nullable = false, length = 500)
+    private String groupDc;
+
+    @Column(name="group_img", columnDefinition = "TEXT", nullable = true)
+    private String groupImg;
+
+    @Column(name = "max_user_count", nullable = false)
+    private Integer maxUserCount;
+
+    @Column(name = "create_dt")
+    private LocalDateTime createDt;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    public GroupDto toDto(){
+        return GroupDto.builder()
+                .groupId(this.groupId)
+                .groupNm(this.groupNm)
+                .groupDc(this.groupDc)
+                .groupImg(this.groupImg)
+                .maxUserCount(this.maxUserCount)
+                .startTime(this.startTime)
+                .endTime(this.endTime)
+                .build();
+    }
+}

--- a/src/main/java/com/wasd/group/entity/GroupUser.java
+++ b/src/main/java/com/wasd/group/entity/GroupUser.java
@@ -1,0 +1,42 @@
+package com.wasd.group.entity;
+
+import com.wasd.group.dto.GroupUserDto;
+import com.wasd.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "group_user_info")
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long groupUserId;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "role", nullable = false)
+    private Integer role;
+
+
+    public GroupUserDto toDto(){
+        return GroupUserDto.builder()
+                .groupUserId(this.groupUserId)
+                .group(this.group.toDto())
+                .user(this.user.toDto())
+                .role(this.role)
+                .build();
+    }
+}

--- a/src/main/java/com/wasd/group/repository/GroupRepository.java
+++ b/src/main/java/com/wasd/group/repository/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.wasd.group.repository;
+
+import com.wasd.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+}

--- a/src/main/java/com/wasd/group/repository/GroupUserRepository.java
+++ b/src/main/java/com/wasd/group/repository/GroupUserRepository.java
@@ -1,0 +1,9 @@
+package com.wasd.group.repository;
+
+import com.wasd.group.entity.Group;
+import com.wasd.group.entity.GroupUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupUserRepository extends JpaRepository<GroupUser, Long> {
+
+}

--- a/src/main/java/com/wasd/group/service/GroupService.java
+++ b/src/main/java/com/wasd/group/service/GroupService.java
@@ -1,0 +1,19 @@
+package com.wasd.group.service;
+
+import com.wasd.gameInfo.service.GameInfoService;
+import com.wasd.group.repository.GroupRepository;
+import com.wasd.group.repository.GroupUserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupUserRepository groupUserRepository;
+    private final GameInfoService gameInfoService;
+
+
+
+}

--- a/src/main/java/com/wasd/user/entity/User.java
+++ b/src/main/java/com/wasd/user/entity/User.java
@@ -8,7 +8,7 @@ import lombok.*;
 import java.time.LocalTime;
 
 @Entity
-@Table(name="user_info")
+@Table(name = "user_info")
 @Builder
 @Getter
 @ToString


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 기타

### 작업 사항

close #30 

- 그룹게임정보 RestAPI 구현
  - 생성, 수정, 삭제의 경우는 Service단 구현 (Group 에서 사용할 것)

- 그룹 정보 기본 테이블 생성 (로직 구현X)

### 추가 정보

![image](https://github.com/user-attachments/assets/c0235d2f-1934-42ba-83e0-5198ce3b2904)

1. 그룹 아이디로 선택한 그룹의 게임 정보 조회
  1.1그룹 정보 수정 시 사용

2. 선택한 게임에 해당하는 그룹_게임 목록 조회
  2.1 그룹 목록 조회할 때 사용
  2.2 모든 Group 정보 조회 후 group_id로 그룹_게임 목록을 조회하는건 비효율적이라 판단
  -> gameId로 그룹_게임 목록 조회 후 그 정보로 Group 정보 조회 예정


- groupGameInfo 테이블 정보는 노션 참고

---

### 스크린샷 (필요시)

![image](https://github.com/user-attachments/assets/dbb8b0ed-c7e0-481e-b01f-570d1b418d64)

![image](https://github.com/user-attachments/assets/ed8bd50c-42f4-4e7a-b8be-16ed559ed41d)






### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?

