### PR TITLE
[FEAT] 그룹 상세정보 조회

### DIFF
--- a/src/main/java/com/wasd/common/controller/PageController.java
+++ b/src/main/java/com/wasd/common/controller/PageController.java
@@ -1,17 +1,25 @@
 package com.wasd.common.controller;
 
 import com.wasd.config.security.CustomOAuth2User;
+import com.wasd.group.dto.GroupDto;
+import com.wasd.group.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Collection;
 
 @Controller
 public class PageController {
+
+    @Autowired
+    private GroupService groupService;
+
     @GetMapping({"/login", "/"})
     public String loginPage(@AuthenticationPrincipal CustomOAuth2User oAuth2User){
         if (oAuth2User != null) {
@@ -58,5 +66,16 @@ public class PageController {
     @GetMapping("/main/group/new")
     public String mainGroupNewPage(){
         return "/pages/group/groupNew";
+    }
+
+    @GetMapping("/main/group/view")
+    public String mainGroupViewPage(@RequestParam Long groupId, Model model){
+
+        if(groupId !=null){
+            GroupDto groupDto = groupService.findGroupByGroupId(groupId);
+            model.addAttribute("groupInfo", groupDto);
+        }
+
+        return "/pages/group/groupView";
     }
 }

--- a/src/main/java/com/wasd/group/service/GroupService.java
+++ b/src/main/java/com/wasd/group/service/GroupService.java
@@ -82,9 +82,11 @@ public class GroupService {
      * @return
      */
     public GroupDto findGroupByGroupId(Long groupId){
-        return groupRepository.findById(groupId)
-                .orElseThrow(() -> new RuntimeException("그룹 아이디에 해당하는 정보가 없습니다."))
-                .toDto();
+        return groupGameInfoRepository.findByGroupId(groupId)
+                .map(groupGameInfo -> groupRepository.findById(groupId)
+                        .orElseThrow(() -> new RuntimeException("그룹 아이디에 해당하는 정보가 없습니다."))
+                        .toDto(groupGameInfo.getGameInfo().toDto()))
+                .orElseThrow(() -> new RuntimeException("해당 그룹의 게임 정보가 없습니다."));
     }
 
     /**

--- a/src/main/resources/static/css/group/groupDetail.css
+++ b/src/main/resources/static/css/group/groupDetail.css
@@ -1,4 +1,4 @@
-.groupDetail-box{
+.groupDetail-box {
     width: 100%;
     height: 100%;
     display: flex;
@@ -19,7 +19,7 @@
 /*overflow-y: auto;*/
 
 
-.groupDetail-info-box{
+.groupDetail-info-box {
     background: var(--back-bg);
     display: flex;
     flex-direction: column;
@@ -27,59 +27,63 @@
     padding: 30px 20px;
 }
 
-.groupDetail-info-title-box{
+.groupDetail-info-title-box {
     display: flex;
     gap: 10px;
     align-items: center;
     margin-bottom: 30px;
+
+    position: relative;
 }
 
-.groupDetail-info-title{
+.groupDetail-info-title {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow-x: hidden;
     flex: 1;
 }
 
-.groupDetail-info-menu-btn{
+.groupDetail-info-menu-btn {
     font-size: 15px;
     background: none;
     cursor: pointer;
-    border:none;
-    color:white;
+    border: none;
+    color: white;
+    height: 100%;
+    width: 30px;
 }
 
-.groupDetail-info-users-box{
+.groupDetail-info-users-box {
     flex: 1;
     display: flex;
     flex-direction: column;
     gap: 20px;
 }
 
-.groupDetail-info-user{
+.groupDetail-info-user {
     display: flex;
     gap: 10px;
     align-items: center;
 }
 
-.groupDetail-info-user img{
+.groupDetail-info-user img {
     width: 1.8rem;
     height: 1.8rem;
     border-radius: 10px;
     object-fit: cover;
 }
 
-.groupDetail-info-user i{
+.groupDetail-info-user i {
     color: #FFE400;
 }
 
-.groupDetail-info-user span{
+.groupDetail-info-user span {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow-x: hidden;
 }
 
-.groupDetail-chat-box{
+.groupDetail-chat-box {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -87,7 +91,7 @@
 }
 
 
-.groupDetail-chat-list-box{
+.groupDetail-chat-list-box {
     display: flex;
     flex-direction: column;
     gap: 40px;
@@ -114,7 +118,7 @@
     display: none;
 }
 
-.groupDetail-chat-write-box{
+.groupDetail-chat-write-box {
     display: flex;
     gap: 10px;
     height: 100px;
@@ -124,7 +128,7 @@
     padding: 0 5px;
 }
 
-.groupDetail-chat-write-box .chat-write-btn{
+.groupDetail-chat-write-box .chat-write-btn {
     color: white;
     background: var(--group-bg-active);
     width: 45px;
@@ -136,42 +140,86 @@
 }
 
 
-.groupDetail-chat-content{
+.groupDetail-chat-content {
     display: flex;
     gap: 20px;
 }
 
-.groupDetail-chat-content img{
+.groupDetail-chat-content img {
     width: 50px;
     height: 50px;
     border-radius: 50%;
 }
 
-.groupDetail-chat-info{
+.groupDetail-chat-info {
     display: flex;
     flex: 1;
     flex-direction: column;
     gap: 5px;
 }
 
-.chat-info-title{
+.chat-info-title {
     display: flex;
     gap: 10px;
     align-items: center;
 }
-.chat-info-title-username{
+
+.chat-info-title-username {
     font-weight: 600;
 }
 
-.chat-info-title-date{
+.chat-info-title-date {
     font-size: 13px;
     color: lightgray;
 }
 
-.chat-write-textarea{
+.chat-write-textarea {
     height: 90%;
     resize: none;
     color: white;
     font-size: 15px;
     font-weight: 600;
+}
+
+
+/* 그룹 정보 메뉴 css */
+.groupDetail-info-menu-box {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 180px;
+    border: 1px solid var(--input-bg);
+    border-radius: 6px;
+    background: var(--input-bg);
+    list-style-type: none;
+    width: 200px;
+    min-height: 100px;
+    padding: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    z-index: 5;
+}
+
+.groupDetail-info-menu-box li {
+    padding: 10px;
+    cursor: pointer;
+    display:flex;
+    gap: 10px;
+    align-items: center;
+}
+
+
+.groupDetail-info-menu-box li:hover {
+    background-color: var(--back-bg);
+}
+
+.groupDetail-info-menu-box li i{
+    font-size: 14px;
+}
+
+.groupDetail-info-menu-btn:hover + .groupDetail-info-menu-box {
+    display: block;
+}
+
+.groupDetail-info-menu-box:hover{
+    display: block;
 }

--- a/src/main/resources/static/css/group/groupView.css
+++ b/src/main/resources/static/css/group/groupView.css
@@ -1,0 +1,69 @@
+.groupView-box{
+    display: flex;
+    flex-direction: column;
+    gap: 50px;
+    margin:0 auto;
+    width: 100%;
+    max-width: 1000px;
+    height: 100%;
+    min-height: 1000px;
+}
+
+.groupView-title-box{
+    display: flex;
+    gap:20px;
+    align-items: center;
+}
+.groupView-title-box img{
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.groupView-info-box, .groupView-game-box{
+    display: flex;flex-direction: column; gap:40px;
+}
+
+.groupView-game-box{
+    margin-top: 20px;
+}
+.groupView-box .groupView-title{
+    font-size: 18px;
+}
+.groupView-info-limit-box{
+    display: flex;gap:30px
+}
+
+.groupView-info-dc-box{
+    display: flex; gap: 10px;
+    flex-direction: column;
+}
+
+.groupView-info-dc-box span{
+    justify-content: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.groupView-info-dc-box pre{
+    min-width: 100%;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    padding: 0 20px;
+    font-size: 15px;
+}
+
+.groupView-gameNm{
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.groupView-gameNm img{
+    width: 25px;
+    height: 25px;
+    object-fit: cover;
+    border: 10px;
+}

--- a/src/main/resources/static/js/common/common.js
+++ b/src/main/resources/static/js/common/common.js
@@ -55,6 +55,10 @@ function setFieldValue(id, value){
 function popupMainOpen(){
     $('.popup-main').addClass('active');
 
+    setTimeout(function () {
+        $('.popup-main-box').scrollTop(0);
+    }, 50);
+
 }
 // 팝업창 닫기
 function popupMainClose(){

--- a/src/main/resources/static/js/common/fragments/menu.js
+++ b/src/main/resources/static/js/common/fragments/menu.js
@@ -58,7 +58,7 @@ function getMyGroupList(){
             res.forEach(function (item) {
                 addTag += `
                         <div class="groups-collection">
-                            <div class="group group-detail unread" role="button" data-url="/main/group/${item.groupId}" data-groupId="${item.groupId}">
+                            <div class="unread group group-detail" role="button" data-url="/main/group/${item.groupId}" data-groupid="${item.groupId}">
                                 <div class="group-icon"><img src="${item.groupImg}" /></div>
                             </div>
                         </div>

--- a/src/main/resources/static/js/group/group.js
+++ b/src/main/resources/static/js/group/group.js
@@ -103,10 +103,6 @@ function groupNew() {
             initGroupNew();
         }, complete() {
             popupMainOpen();
-
-            setTimeout(function () {
-                $('.popup-main-box').scrollTop(0);
-            }, 50);
         }
     });
 }
@@ -209,5 +205,5 @@ function joinGroup(groupId, groupNm){
 
 // 내 그룹 찾기 -> 화면 전환
 function findGroupDetail(groupId){
-    $("[data-groupId='"+ groupId+"']").trigger("click");
+    $("[data-groupid='"+ groupId+"']").trigger("click");
 }

--- a/src/main/resources/static/js/group/groupDetail.js
+++ b/src/main/resources/static/js/group/groupDetail.js
@@ -2,3 +2,26 @@ function initGroupDetail() {
 
 
 }
+
+// 그룹 정보 조회
+function openGroupInfo(){
+
+    var groupId = $('.group-detail.active').data('groupid')
+    $.ajax({
+        url:'/main/group/view',
+        method:'GET',
+        data:{
+            groupId:groupId
+        },
+        success: function (res) {
+            $('.popup-main-box').html(res);
+            initGroupView();
+            popupMainOpen();
+        },
+        error: function (xhr) {
+            alert(xhr.responseText || '그룹 정보 조회 중 문제가 발생하였습니다. 잠시 후 다시 시도하세요.');
+            popupMainClose();
+        }
+    })
+
+}

--- a/src/main/resources/static/js/group/groupView.js
+++ b/src/main/resources/static/js/group/groupView.js
@@ -1,0 +1,7 @@
+function initGroupView() {
+
+}
+
+function getGameAttrInfo(){
+
+}

--- a/src/main/resources/templates/pages/group/groupDetail.html
+++ b/src/main/resources/templates/pages/group/groupDetail.html
@@ -5,6 +5,11 @@
         <div class="groupDetail-info-title-box">
             <h3 class="groupDetail-info-title">그룹명</h3>
             <button class="groupDetail-info-menu-btn"><i class="fa-solid fa-angle-down"></i></button>
+            <ul class="groupDetail-info-menu-box">
+                <li onclick="openGroupInfo()"><i class="fa-solid fa-circle-info"></i><span>그룹 정보</span></li>
+<!--                <li><i class="fa-solid fa-gear"></i><span>그룹 수정</span></li>-->
+                <li><i class="fa-solid fa-arrow-right-from-bracket"></i><span>나가기</span></li>
+            </ul>
         </div>
 
         <!-- 참여자 목록 -->

--- a/src/main/resources/templates/pages/group/groupView.html
+++ b/src/main/resources/templates/pages/group/groupView.html
@@ -1,0 +1,52 @@
+<div class="groupView-box">
+
+    <div class="groupView-title-box">
+        <img th:src="${groupInfo.groupImg}"/>
+<!--        <h1 th:text="${groupInfo.groupNm}"></h1>-->
+        <h1>TEST</h1>
+    </div>
+
+
+    <div class="groupView-info-box">
+
+        <div class="groupView-info-limit-box" >
+            <div class="groupView-title">
+                <i class="fa-solid fa-user-group"></i>
+                <span th:text="${'최대 ' + groupInfo.maxUserCount + '명'}"></span>
+            </div>
+
+            <div class="groupView-title">
+                <i class="fa-regular fa-clock"></i>
+                <span th:text="${groupInfo.startTime != null ? #strings.substring(groupInfo.startTime, 0, 5) : ''}"></span>
+                <span th:text="${groupInfo.startTime != null || groupInfo.endTime != null ? '~' : 'ALL TIME'}"></span>
+                <span th:text="${groupInfo.endTime != null ? #strings.substring(groupInfo.endTime, 0, 5) : ''}"></span>
+            </div>
+        </div>
+
+        <div class="groupView-info-dc-box">
+            <span class="groupView-title"><i class="fa-solid fa-comment" id="groupDc_icon"></i> 그룹 설명</span>
+            <pre th:text="${groupInfo.groupDc}"></pre>
+        </div>
+    </div>
+
+    <div class="groupView-game-box">
+        <span class="groupView-title"><i class="fa-solid fa-heart"></i> 이런 사람을 선호해요</span>
+
+        <div class="groupView-gameNm">
+            <img th:src="@{${'/images/gameImg/' + groupInfo.gameInfo.gameId + '.png'}}"/>
+            <span th:text="${groupInfo.gameInfo.gameNm}"></span>
+        </div>
+
+
+
+    </div>
+
+
+</div>
+
+
+
+<link th:inline="css" th:href="@{/css/group/groupView.css}" rel="stylesheet"/>
+<script th:inline="javascript" type="text/javascript" th:src="@{/js/group/groupView.js}"></script>
+
+<script th:inline="javascript">var groupInfo = /*[[${groupInfo}]]*/ {};</script>


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 기타

### 작업 사항

- 그룹 채팅방에서 더보기 메뉴 추가
   - 그룹 정보
   - 나가기
- 그룸 정보 클릭 시 팝업으로 그룹 상세정보 조회

### 추가 정보

- 더보기 메뉴에 추가 (그룹장 권한)
  - 그룹 수정
  - 그룹 삭제
- 그룹 정보 조회 팝업에 게임 정보 추가해야됨

---

### 스크린샷 (필요시)

<img width="407" alt="image" src="https://github.com/user-attachments/assets/2ec2f993-658b-4233-a5ce-4028c947d87e">

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/cc4d29e7-5f50-4e70-9f8c-6e30a48a6c75">






### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?

