### PR TITLE
[FEAT] 그룹 정보 조회 기능

### DIFF
--- a/src/main/java/com/wasd/group/service/GroupService.java
+++ b/src/main/java/com/wasd/group/service/GroupService.java
@@ -160,7 +160,7 @@ public class GroupService {
 
         Integer currentUserCount = groupUserRepository.findByGroup_groupId(group.getGroupId()).size();
         if(currentUserCount == group.getMaxUserCount()){
-            throw new WasdException(ErrorCode.ETC,"해당 그룹은 이미 인원이 가득 찼습니다. 다른 그룹을 찾아보시거나 새로운 그룹을 생성해보세요.");
+            throw new WasdException(ErrorCode.ETC,"해당 그룹은 이미 인원이 가득 찼습니다.\n다른 그룹을 찾아보시거나 새로운 그룹을 생성해보세요.");
         }
 
         // 그룹_사용자 생성

--- a/src/main/resources/static/css/group/group.css
+++ b/src/main/resources/static/css/group/group.css
@@ -161,6 +161,16 @@
     gap: 20px; /* 요소 사이의 간격 조절 */
 }
 
-.dc-limit-btn{
-    width: 70px;
+.dc-limit-btn-box{
+    display: flex;
+    gap: 5px;
+    align-items: center;
 }
+.dc-limit-info-btn{
+    width: 40px;
+}
+.dc-limit-join-btn{
+    width: 55px;
+}
+
+

--- a/src/main/resources/static/css/group/groupView.css
+++ b/src/main/resources/static/css/group/groupView.css
@@ -67,3 +67,60 @@
     object-fit: cover;
     border: 10px;
 }
+
+
+
+.groupView-gameInfo-col-item {
+    position: relative;
+    width: 300px;
+    margin-left: 50px;
+    margin-top: 100px;
+}
+
+.groupView-gameInfo-col-item input {
+    font-size: 15px;
+    color: #222222;
+    width: 300px;
+    border: none;
+    border-bottom: solid #aaaaaa 1px;
+    padding-bottom: 10px;
+    padding-left: 10px;
+    position: relative;
+    background: none;
+    z-index: 5;
+}
+
+input::placeholder { color: #aaaaaa; }
+input:focus { outline: none; }
+
+span {
+    display: block;
+    position: absolute;
+    bottom: 0;
+    left: 0%;  /* right로만 바꿔주면 오 - 왼 */
+    background-color: #666;
+    width: 0;
+    height: 2px;
+    border-radius: 2px;
+    transition: 0.5s;
+}
+
+label {
+    position: absolute;
+    color: #aaa;
+    left: 10px;
+    font-size: 20px;
+    bottom: 8px;
+    transition: all .2s;
+}
+
+input:focus ~ label, input:valid ~ label {
+    font-size: 16px;
+    bottom: 40px;
+    color: #666;
+    font-weight: bold;
+}
+
+input:focus ~ span, input:valid ~ span {
+    width: 100%;
+}

--- a/src/main/resources/static/css/group/groupView.css
+++ b/src/main/resources/static/css/group/groupView.css
@@ -6,7 +6,7 @@
     width: 100%;
     max-width: 1000px;
     height: 100%;
-    min-height: 1000px;
+    min-height: 650px;
 }
 
 .groupView-title-box{
@@ -59,6 +59,7 @@
     display: flex;
     gap: 10px;
     align-items: center;
+    padding: 0 20px;
 }
 
 .groupView-gameNm img{
@@ -68,59 +69,36 @@
     border: 10px;
 }
 
+.groupView-gameInfo{
+    gap: 30px;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    padding: 0 20px;
+}
 
+
+.groupView-gameInfo-col{
+    display: flex;
+    align-items: center;
+    gap: 30px;
+}
 
 .groupView-gameInfo-col-item {
-    position: relative;
-    width: 300px;
-    margin-left: 50px;
-    margin-top: 100px;
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .groupView-gameInfo-col-item input {
-    font-size: 15px;
-    color: #222222;
-    width: 300px;
-    border: none;
-    border-bottom: solid #aaaaaa 1px;
-    padding-bottom: 10px;
-    padding-left: 10px;
-    position: relative;
-    background: none;
-    z-index: 5;
-}
-
-input::placeholder { color: #aaaaaa; }
-input:focus { outline: none; }
-
-span {
-    display: block;
-    position: absolute;
-    bottom: 0;
-    left: 0%;  /* right로만 바꿔주면 오 - 왼 */
-    background-color: #666;
-    width: 0;
-    height: 2px;
-    border-radius: 2px;
-    transition: 0.5s;
-}
-
-label {
-    position: absolute;
-    color: #aaa;
-    left: 10px;
-    font-size: 20px;
-    bottom: 8px;
-    transition: all .2s;
-}
-
-input:focus ~ label, input:valid ~ label {
-    font-size: 16px;
-    bottom: 40px;
-    color: #666;
-    font-weight: bold;
-}
-
-input:focus ~ span, input:valid ~ span {
+    color: white;
     width: 100%;
+    border: none;
+    border-radius: 5px;
+    border-bottom: solid var(--group-bg-active) 1px;
+}
+
+.groupView-gameInfo-col-item label {
+    color: white;
+    font-size: 17px;
 }

--- a/src/main/resources/static/js/group/group.js
+++ b/src/main/resources/static/js/group/group.js
@@ -153,7 +153,8 @@ function getAllGroupList() {
                                         </div>
                                     </div>
                                     <div class="dc-limit-btn-box">
-                                        <button class="dc-limit-btn bt" onclick="joinGroup(${item.groupId}, '${item.groupNm}')"><i class="fa-solid fa-arrow-right-to-bracket"></i></button>
+                                        <button class="dc-limit-info-btn bt" onclick="infoGroup(${item.groupId})"><i class="fa-solid fa-info"></i></button>
+                                        <button class="dc-limit-join-btn bt" onclick="joinGroup(${item.groupId}, '${item.groupNm}')"><i class="fa-solid fa-arrow-right-to-bracket"></i></button>
                                     </div>
                                 </div>
                             </div>
@@ -201,6 +202,19 @@ function joinGroup(groupId, groupNm){
             util.alert('error', xhr.responseJSON.msg || '서버 오류가 발생했습니다. 다시 시도해 주세요.' ,'',undefined,undefined);
         }
     })
+}
+
+// 그룹 정보 조회
+function infoGroup(groupId){
+    // HTML 가져오기
+    util.ajaxPromise({
+        url: '/main/group/view',
+        method: 'GET',
+        dataType: 'html'
+    }).then(res => {
+        $('.popup-main-box').html(res);
+        groupView.init(groupId);
+    });
 }
 
 // 내 그룹 찾기 -> 화면 전환

--- a/src/main/resources/static/js/group/groupDetail.js
+++ b/src/main/resources/static/js/group/groupDetail.js
@@ -32,55 +32,21 @@ var groupDetail = {
     // 그룹 정보 조회
     async openGroupInfo() {
         this.groupId = $('.group-detail.active').data('groupid');
-        try {
-            await Promise.all([
-                // html
-                util.ajaxPromise({ url: '/main/group/view', method: 'GET', dataType: 'html' })
-                    .then(res => {
-                        // initGroupView();
-                        popupMainOpen();
-                        $('.popup-main-box').html(res);
-                    }),
-                // json
-                util.ajaxPromise({ url: `/group/${this.groupId}`, method: 'GET', dataType: 'json' })
-                    .then(data => {
-                        // 그룹 정보로 HTML 요소 업데이트
-                        $('.groupView-title-box img').attr('src', data.groupImg); // 이미지 업데이트
-                        $('.groupView-title-box h1').text(data.groupNm); // 그룹 이름 업데이트
-                        $('.groupView-info-limit-box .groupView-title').eq(0).find('span').text(`최대 ${data.maxUserCount}명`); // 최대 인원수
-                        $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(0).text(data.startTime ? data.startTime.substring(0, 5) : ''); // 시작 시간
-                        $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(1).text(data.startTime || data.endTime ? '~' : 'ALL TIME'); // 시간 표시
-                        $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(2).text(data.endTime ? data.endTime.substring(0, 5) : ''); // 종료 시간
-                        $('.groupView-info-dc-box pre').text(data.groupDc); // 그룹 설명 업데이트
-                        $('.groupView-gameNm img').attr('src', `/images/gameImg/${data.gameInfo.gameId}.png`); // 게임 이미지 업데이트
-                        $('.groupView-gameNm span').text(data.gameInfo.gameNm); // 게임 이름 업데이트
 
-                        return data.gameInfo;
-                    })
-                    // .then(userGameInfo => {
-                    //     util.ajaxPromise({ url: `/gameInfo/${userGameInfo.gameId}`, method: 'GET', dataType: 'json' })
-                    //         .then(gameData => {
-                    //
-                    //
-                    //
-                    //             console.log(gameData);
-                    //         })
-                    // })
-            ]);
-        } catch (error) {
-            console.log(error);
-            util.alert('error', '그룹 정보 조회 중 문제가 발생하였습니다. 잠시 후 다시 시도하세요.', '',undefined,undefined);
-            popupMainClose();
-        }
+        // HTML 가져오기
+        var htmlData = await util.ajaxPromise({
+            url: '/main/group/view',
+            method: 'GET',
+            dataType: 'html'
+        });
+        $('.popup-main-box').html(htmlData);
 
-        popupMainOpen();
-
+        groupView.init(this.groupId);
     },
 
     // 초기화 (중복 방지)
     destroy(){
         this.groupId = null;
-        this.userGameInfo = {};
         $('#group-dtl-li').off('click', this.openGroupInfo.bind(this));
         $('#chat-submit').off('click', sendMessage);
         $('#chat-text').off('keydown');
@@ -88,7 +54,3 @@ var groupDetail = {
         disconnect();
     }
 };
-
-function initGroupDetail() {
-    groupDetail.init();
-}

--- a/src/main/resources/static/js/group/groupDetail.js
+++ b/src/main/resources/static/js/group/groupDetail.js
@@ -44,7 +44,6 @@ var groupDetail = {
                 // json
                 util.ajaxPromise({ url: `/group/${this.groupId}`, method: 'GET', dataType: 'json' })
                     .then(data => {
-                        console.log(data);
                         // 그룹 정보로 HTML 요소 업데이트
                         $('.groupView-title-box img').attr('src', data.groupImg); // 이미지 업데이트
                         $('.groupView-title-box h1').text(data.groupNm); // 그룹 이름 업데이트
@@ -55,9 +54,21 @@ var groupDetail = {
                         $('.groupView-info-dc-box pre').text(data.groupDc); // 그룹 설명 업데이트
                         $('.groupView-gameNm img').attr('src', `/images/gameImg/${data.gameInfo.gameId}.png`); // 게임 이미지 업데이트
                         $('.groupView-gameNm span').text(data.gameInfo.gameNm); // 게임 이름 업데이트
+
+                        return data.gameInfo;
                     })
+                    // .then(userGameInfo => {
+                    //     util.ajaxPromise({ url: `/gameInfo/${userGameInfo.gameId}`, method: 'GET', dataType: 'json' })
+                    //         .then(gameData => {
+                    //
+                    //
+                    //
+                    //             console.log(gameData);
+                    //         })
+                    // })
             ]);
         } catch (error) {
+            console.log(error);
             util.alert('error', '그룹 정보 조회 중 문제가 발생하였습니다. 잠시 후 다시 시도하세요.', '',undefined,undefined);
             popupMainClose();
         }
@@ -69,6 +80,7 @@ var groupDetail = {
     // 초기화 (중복 방지)
     destroy(){
         this.groupId = null;
+        this.userGameInfo = {};
         $('#group-dtl-li').off('click', this.openGroupInfo.bind(this));
         $('#chat-submit').off('click', sendMessage);
         $('#chat-text').off('keydown');

--- a/src/main/resources/static/js/group/groupView.js
+++ b/src/main/resources/static/js/group/groupView.js
@@ -1,7 +1,73 @@
-function initGroupView() {
+var groupView = {
 
-}
+    groupId: null,
+    init(groupId){
+        this.destroy();
 
-function getGameAttrInfo(){
+        this.groupId = groupId; // ID 설정
+        this.setGroupInfo();    // 그룹정보 설정
 
+        this.domEvt();          // 이벤트
+    },
+    domEvt(){
+        $('.popup-main-close-btn').on('click', function(){  // 팝업 창 닫으면 내용 초기화
+            this.destroy();
+        });
+    },
+    async setGroupInfo() {
+
+        try {
+            // 그룹 정보 JSON 조회
+            var groupData = await util.ajaxPromise({
+                url: `/group/${this.groupId}`,
+                method: 'GET',
+                dataType: 'json'
+            });
+
+            // 그룹 정보로 HTML 요소 업데이트
+            $('.groupView-title-box img').attr('src', groupData.groupImg);
+            $('.groupView-title-box h1').text(groupData.groupNm);
+            $('.groupView-info-limit-box .groupView-title').eq(0).find('span').text(`최대 ${groupData.maxUserCount}명`);
+            $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(0).text(groupData.startTime ? groupData.startTime.substring(0, 5) : '');
+            $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(1).text(groupData.startTime || groupData.endTime ? '~' : 'ALL TIME');
+            $('.groupView-info-limit-box .groupView-title').eq(1).find('span').eq(2).text(groupData.endTime ? groupData.endTime.substring(0, 5) : '');
+            $('.groupView-info-dc-box pre').text(groupData.groupDc);
+            $('.groupView-gameNm img').attr('src', `/images/gameImg/${groupData.gameInfo.gameId}.png`);
+            $('.groupView-gameNm span').text(groupData.gameInfo.gameNm);
+
+            // 게임 정보 JSON 조회
+            var gameInfoData = await util.ajaxPromise({
+                url: `/gameInfo/${groupData.gameInfo.gameId}`,
+                method: 'GET',
+                dataType: 'json'
+            });
+
+            // 그룹 정보의 value 값 한글명으로 변환
+            $('#groupView-gameInfo').empty();
+            var addTag='';
+            for (const gameAttr in gameInfoData.info) {
+                var selectedValue = groupData.gameInfo.info[gameAttr] || '';            // 그룹장이 선택한 값
+                var selectedText = gameInfoData.info[gameAttr][selectedValue] || '';    // 선택한 값의 이름
+                addTag += `
+                    <div class="groupView-gameInfo-col-item">
+                        <label>${gameInfoData.info[gameAttr].infoNm}</label>
+                        <input type="text" value="${selectedText}" disabled>
+                    </div>
+                `;
+            }
+            $('#groupView-gameInfo').append(addTag);
+
+            popupMainOpen(); // 팝업 OPEN
+
+        } catch (error) {
+            util.alert('error', '그룹 정보 조회 중 문제가 발생하였습니다. 잠시 후 다시 시도하세요.', '',undefined,undefined);
+
+            popupMainClose();
+            this.destroy();
+        }
+    },
+    destroy(){
+        this.groupId = null;
+        $('.popup-main-close-btn').off('click');
+    }
 }

--- a/src/main/resources/templates/pages/group/group.html
+++ b/src/main/resources/templates/pages/group/group.html
@@ -51,7 +51,8 @@
                                 </div>
                             </div>
                             <div class="dc-limit-btn-box">
-                                <button class="dc-limit-btn bt"><i class="fa-solid fa-arrow-right-to-bracket"></i></button>
+                                <button class="dc-limit-info-btn bt" ><i class="fa-solid fa-info"></i></button>
+                                <button class="dc-limit-join-btn bt"><i class="fa-solid fa-arrow-right-to-bracket"></i></button>
 
                             </div>
                         </div>

--- a/src/main/resources/templates/pages/group/groupView.html
+++ b/src/main/resources/templates/pages/group/groupView.html
@@ -2,8 +2,7 @@
 
     <div class="groupView-title-box">
         <img />
-<!--        <h1 th:text="${groupInfo.groupNm}"></h1>-->
-        <h1>TEST</h1>
+        <h1></h1>
     </div>
 
 
@@ -30,15 +29,39 @@
     </div>
 
     <div class="groupView-game-box">
-        <span class="groupView-title"><i class="fa-solid fa-heart"></i> 이런 사람을 선호해요</span>
+        <span class="groupView-title"><i class="fa-regular fa-lightbulb"></i> 이런 사람을 선호해요</span>
 
         <div class="groupView-gameNm">
             <img />
             <span></span>
         </div>
 
-
-
+        <div class="groupView-gameInfo">
+            <div class="groupView-gameInfo-col">
+                <div class="groupView-gameInfo-col-item">
+                    <input type="text" >
+                    <label>티어</label>
+                    <span>골드</span>
+                </div>
+                <div class="groupView-gameInfo-col-item">
+                    <input type="text" >
+                    <label>라인</label>
+                    <span>탑</span>
+                </div>
+            </div>
+            <div class="groupView-gameInfo-col">
+                <div class="groupView-gameInfo-col-item">
+                    <input type="text" >
+                    <label>티어</label>
+                    <span>골드</span>
+                </div>
+                <div class="groupView-gameInfo-col-item">
+                    <input type="text" >
+                    <label>라인</label>
+                    <span>탑</span>
+                </div>
+            </div>
+        </div>
     </div>
 
 
@@ -48,5 +71,3 @@
 
 <link th:inline="css" th:href="@{/css/group/groupView.css}" rel="stylesheet"/>
 <script th:inline="javascript" type="text/javascript" th:src="@{/js/group/groupView.js}"></script>
-
-<script th:inline="javascript">var groupInfo = /*[[${groupInfo}]]*/ {};</script>

--- a/src/main/resources/templates/pages/group/groupView.html
+++ b/src/main/resources/templates/pages/group/groupView.html
@@ -29,38 +29,15 @@
     </div>
 
     <div class="groupView-game-box">
-        <span class="groupView-title"><i class="fa-regular fa-lightbulb"></i> 이런 사람을 선호해요</span>
+        <span class="groupView-title"><i class="fa-solid fa-lightbulb"></i> 이런 사람을 선호해요</span>
 
         <div class="groupView-gameNm">
             <img />
             <span></span>
         </div>
 
-        <div class="groupView-gameInfo">
-            <div class="groupView-gameInfo-col">
-                <div class="groupView-gameInfo-col-item">
-                    <input type="text" >
-                    <label>티어</label>
-                    <span>골드</span>
-                </div>
-                <div class="groupView-gameInfo-col-item">
-                    <input type="text" >
-                    <label>라인</label>
-                    <span>탑</span>
-                </div>
-            </div>
-            <div class="groupView-gameInfo-col">
-                <div class="groupView-gameInfo-col-item">
-                    <input type="text" >
-                    <label>티어</label>
-                    <span>골드</span>
-                </div>
-                <div class="groupView-gameInfo-col-item">
-                    <input type="text" >
-                    <label>라인</label>
-                    <span>탑</span>
-                </div>
-            </div>
+        <div class="groupView-gameInfo" id="groupView-gameInfo">
+
         </div>
     </div>
 


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 기타

### 작업 사항

- 기존에는 그룹 목록 화면에서 그룹 정보를 일부분만 조회 가능했음 -> 상세조회 버튼 추가하여 클릭 시 전제 정보 확인 가능
- 채팅방에서 그룹 정보 메뉴 선택 시 그룹 정보 확인 가능

### 추가 정보
추가적인 정보나 설명이 필요할 경우 작성해주세요.

- 기존에는 groupDetail.js에 openGroupInfo 함수안에서 groupView 정보 설정하도록 되어있었음 -> BUT 그룹 목록에도 동일하게 기능 사용할 거 같아서 groupView.js로 이동함 (js 구조 맞게 구현했는지 확인 부탁)


---

### 스크린샷 (필요시)

[ 그룹 목록 ]

![image](https://github.com/user-attachments/assets/6a996494-50a5-44a3-b412-feb9891dc96d)

[ 그룹 채팅방 내 메뉴 ]

![image](https://github.com/user-attachments/assets/311293ad-3255-4520-868d-5f2d6e818d3c)


[ 그룹 정보 조회  ]

![image](https://github.com/user-attachments/assets/dfbeebda-c0f2-4076-bb04-a98840038346)


### 체크리스트

- [x] 빌드에 성공했나요?
- [x] 테스트 성공했나요?
- [x] **표준 출력**과 같은 로그 출력 코드를 모두 제거하셨나요?

